### PR TITLE
Add .env, docker-compose support for quick testing

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,2 @@
+TAVILY_API_KEY=<your-tavily-api-key>
+OPENAI_API_KEY=<your-openai-api-key>

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# .gitignore
+
+.env
+
+outputs/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY . .
+
+RUN pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 5000
+EXPOSE 8000
+
+CMD ["python", "app.py"]

--- a/app.py
+++ b/app.py
@@ -1,8 +1,12 @@
 from multiprocessing import Process
-from backend.server import backend_app
+
+from dotenv import load_dotenv
 from flask import Flask, send_from_directory
 from flask_cors import CORS
 
+from backend.server import backend_app
+
+load_dotenv()
 CORS(backend_app)
 
 

--- a/app.py
+++ b/app.py
@@ -26,10 +26,10 @@ def serve_outputs(path):
 
 
 def run_frontend():
-    frontend_app.run(port=5000)
+    frontend_app.run(host='0.0.0.0', port=5000)
 
 def run_backend():
-    backend_app.run(port=8000)
+    backend_app.run(host='0.0.0.0', port=8000)
 
 if __name__ == '__main__':
     # Start the backend server

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.8'
+services:
+  gpt-newspaper:
+    build:
+      context: .
+    ports:
+      - "5000:5000"
+      - "8000:8000"
+
+    env_file:
+      - .env

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ flask
 json5
 Flask-CORS
 langchain_openai
+python-dotenv


### PR DESCRIPTION
Adding `.env` and `.gitignore` support to the repository enhances flexibility, collaboration, scalability, and adherence to best practices, fostering a more robust and maintainable codebase. Docker-compose enables also fast deployment. 