### PR TITLE
change model to gpt-4 turbo, add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+outputs/

--- a/backend/agents/critique.py
+++ b/backend/agents/critique.py
@@ -24,7 +24,7 @@ class CritiqueAgent:
         }]
 
         lc_messages = convert_openai_messages(prompt)
-        response = ChatOpenAI(model='gpt-4', max_retries=1).invoke(lc_messages).content
+        response = ChatOpenAI(model='gpt-4-turbo-preview', max_retries=1).invoke(lc_messages).content
         if response == 'None':
             return {'critique': None}
         else:

--- a/backend/agents/curator.py
+++ b/backend/agents/curator.py
@@ -30,7 +30,7 @@ class CuratorAgent:
         }]
 
         lc_messages = convert_openai_messages(prompt)
-        response = ChatOpenAI(model='gpt-4-0125-preview', max_retries=1).invoke(lc_messages).content
+        response = ChatOpenAI(model='gpt-4-turbo-preview', max_retries=1).invoke(lc_messages).content
         chosen_sources = response
         for i in sources:
             if i["url"] not in chosen_sources:

--- a/backend/agents/writer.py
+++ b/backend/agents/writer.py
@@ -59,7 +59,7 @@ class WriterAgent:
             "response_format": {"type": "json_object"}
         }
 
-        response = ChatOpenAI(model='gpt-4-0125-preview', max_retries=1, model_kwargs=optional_params).invoke(lc_messages).content
+        response = ChatOpenAI(model='gpt-4-turbo-preview', max_retries=1, model_kwargs=optional_params).invoke(lc_messages).content
         return json.loads(response)
 
     def revise(self, article: dict):
@@ -83,7 +83,7 @@ class WriterAgent:
             "response_format": {"type": "json_object"}
         }
 
-        response = ChatOpenAI(model='gpt-4-0125-preview', max_retries=1, model_kwargs=optional_params).invoke(lc_messages).content
+        response = ChatOpenAI(model='gpt-4-turbo-preview', max_retries=1, model_kwargs=optional_params).invoke(lc_messages).content
         response = json.loads(response)
         print(f"For article: {article['title']}")
         print(f"Writer Revision Message: {response['message']}\n")


### PR DESCRIPTION
Changed model to gpt-4-turbo-preview, has better context and is much cheaper compared to gpt-4 APIs.

Created .gitignore and added outputs folder.